### PR TITLE
Fallback to console input when GUI is unavailable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "robotframework-nl"
-version = "2.0.0"
+version = "2.1.0"
 description = "robotnl is a proving ground to boost Robot framework closer to Natural Language."
 readme = "README.md"
 authors = [{ name = "Johan Foederer", email = "github@famfoe.nl" }]

--- a/robotnl/version.py
+++ b/robotnl/version.py
@@ -1,1 +1,1 @@
-VERSION = '2.0.0'
+VERSION = '2.1.0'


### PR DESCRIPTION
An issue was reported where importing the library failed on a console only environment. This was caused by some early initialization for the keywords involved in [hybrid manual testing](https://github.com/JFoederer/robotframeworkNL/tree/hybrid-manual-testing-from-console#hybrid-manual-testing). The initialization is now lazy and the **Check manual** and **Check interactive** keywords have been extended to also support input from console when running in an environment without GUI capabilities.