### PR TITLE
Use Robot's internal type converters

### DIFF
--- a/atest/robotNL tests/Check that/Operators/Basic_operators.robot
+++ b/atest/robotNL tests/Check that/Operators/Basic_operators.robot
@@ -3,17 +3,17 @@ Resource          base.resource
 
 *** Test Cases ***
 All basic operators are available as text
-    Check that    1    equals    1
-    Check that    1    does not equal    2
-    Check that    1    is less than    2
-    Check that    2    is greater than    1
-    Check that    1    is less than or equal to    1
-    Check that    1    is greater than or equal to    1
+    Check that    ${1}    equals    ${1}
+    Check that    ${1}    does not equal    ${2}
+    Check that    ${1}    is less than    ${2}
+    Check that    ${2}    is greater than    ${1}
+    Check that    ${1}    is less than or equal to    ${1}
+    Check that    ${1}    is greater than or equal to    ${1}
 
 All basic operators are available as symbol
-    Check that    1    =    1
-    Check that    1    ≠    2
-    Check that    1    <    2
-    Check that    2    >    1
-    Check that    1    ≤    1
-    Check that    1    ≥    1
+    Check that    ${1}    =    ${1}
+    Check that    ${1}    ≠    ${2}
+    Check that    ${1}    <    ${2}
+    Check that    ${2}    >    ${1}
+    Check that    ${1}    ≤    ${1}
+    Check that    ${1}    ≥    ${1}

--- a/atest/robotNL tests/Check that/Operators/Typed_checks.robot
+++ b/atest/robotNL tests/Check that/Operators/Typed_checks.robot
@@ -1,0 +1,89 @@
+*** Settings ***
+Resource          base.resource
+Library           typed_keywords.py
+
+*** Test Cases ***
+str comparisons
+    Check that    one    equals    one
+    Check that    ONE    equals    one
+    Check that    ÖNé    equals    öné
+    Check that    one    does not equal    two
+    Check that    \ one \    does not equal    one
+
+int comparisons
+    Check that    1    equals    1
+    Check that    ${1}    equals    ${1}
+    Check that    ${1}    equals    1
+    Check that    1    equals    ${1}
+    Check that    ${1}    does not equal    11
+    Check that    ${1}    does not equal    random text
+    Check that    random text    does not equal    ${1}
+
+float comparisons
+    Check that    1.2    equals    1.2
+    Check that    ${1.2}    equals    ${1.2}
+    Check that    ${1/7}    equals    ${1/7}
+    Check that    ${1.2}    equals    1.2
+    Check that    1.20    equals    ${1.20}
+    Check that    1    equals    ${1.0}
+    Check that    ${1.0}    equals    1
+    Check that    ${1.20}    equals    1.2
+    Check that    1.20    equals    ${1.2}
+    Check that    1.0    equals    ${1}
+    Check that    ${1}    equals    1.0
+    Check that    ${1.2}    does not equal    1.21
+    Check that    ${1.2}    does not equal    random text
+
+bool comparisons
+    Check that    True
+    Check that    ${True}
+    Check that    True    equals    True
+    Check that    True    equals    ${True}
+    Check that    ${True}    equals    true
+    Check that    false    equals    ${False}
+    Check that    ${False}    equals    False
+    Run Keyword And Expect Error    CheckFailed: Requirement check on 'False'    Check That    False
+    Run Keyword And Expect Error    CheckFailed: Requirement check on 'False'    Check That    ${False}
+    Run Keyword And Expect Error    CheckFailed: Requirement check on 'Random text'    Check That    Random text
+    Run Keyword And Expect Error    CheckFailed: Requirement check on 'PASS'    Check That    PASS
+    Run Keyword And Expect Error    CheckFailed: Requirement check on 'yes'    Check that    yes
+    Check that    ${True}    does not equal    random text
+    Check that    True    does not equal    yes
+    Check that    ${true}    equals    yes
+    Check that    ${False}    equals    no
+    Check that    on    equals    ${True}
+    Check that    off    equals    ${false}
+
+enum comparisons
+    Check that    shape with 3 sides    equals    shape with 3 sides
+    ${triangle}=    shape with 3 sides
+    Check that    ${triangle}    equals    shape with 3 sides
+    Check that    shape with 3 sides    equals    TRIANGLE
+    Check that    shape with 3 sides    equals    triANGLE
+    Check that    TRIANGLE    equals    shape with 3 sides
+    Check that    shape with 3 sides    does not equal    3
+    Check that    shape with 3 sides    does not equal    shape with 4 sides
+
+intenum comparisons
+    Reset level
+    Check that    current level    equals    current level
+    Check that    current level    equals    0
+    Check that    current level    equals    ${0}
+    Check that    current level    equals    OFF
+    Check that    current level    equals    off
+    Check that    0    equals    current level
+    Check that    ${0}    equals    current level
+    Check that    OFF    equals    current level
+    Check that    Off    equals    current level
+    Increase level
+    Increase level
+    ${stored level}=    current level
+    Check that    current level    equals    ${stored level}
+    Check that    ${stored level}    equals    current level
+    Check that    ${stored level}    equals    2
+    Check that    ${stored level}    equals    ${2}
+    Check that    ${stored level}    equals    L2
+    Increase level
+    Check that    current level    equals    MAX
+    Check that    current level    does not equal    ${stored level}
+    Check that    ${stored level}    is less than    current level

--- a/atest/robotNL tests/Check that/Operators/typed_keywords.py
+++ b/atest/robotNL tests/Check that/Operators/typed_keywords.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from enum import Enum, IntEnum
+
+from robot.api.deco import keyword, library
+
+
+class Shape(Enum):
+    TRIANGLE = 3
+    RECTANGLE = 4
+
+
+class Level(IntEnum):
+    OFF = 0
+    L1 = 1
+    L2 = 2
+    MAX = 3
+
+
+class typed_keywords:
+    @keyword("shape with ${n} sides")
+    def shape_with_n_sides(self, n: int):
+        return Shape(n)
+
+    @keyword("Reset level")
+    def reset(self):
+        self.level = Level(0)
+
+    @keyword("Increase level")
+    def increase(self):
+        if self.level.name != 'MAX':
+            self.level = Level(self.level+1)
+
+    @keyword("current level")
+    def current_level(self):
+        return self.level

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "robotframework-nl"
-version = "2.1.1"
+version = "2.2.0"
 description = "robotnl is a proving ground to boost Robot framework closer to Natural Language."
 readme = "README.md"
 authors = [{ name = "Johan Foederer", email = "github@famfoe.nl" }]

--- a/robotnl/RobotChecks.py
+++ b/robotnl/RobotChecks.py
@@ -67,32 +67,32 @@ class RobotChecks:
         """
         Identical to `check that` but for use in precondition checks. Execution will not continue
         on failure.
-        
+
         Precondition checks are used to validate assumptions made at the start of a test case or
         keyword. When a precondition check fails it indicates that the test case did not reach the
-        point where it was able to check the requirement it was testing for.  
+        point where it was able to check the requirement it was testing for.
         """
         try:
             return RobotChecks.__execute_check("Precondition", *args)
         except CheckFailed as failure:
             failure.ROBOT_CONTINUE_ON_FAILURE = False
-            raise failure            
+            raise failure
 
     def check_postcondition(self, *args):
         """
         Identical to `check that` but for use in postcondition checks. Execution will not continue
         on failure.
-        
+
         Postcondition checks are typically used in reusable keywords. They are added to assert that
         the expected result of the action was achieved successfully. A failing postcondition check
         causes the test case to fail, but indicates that the requirement it was testing for was not
-        the cause of failure. 
+        the cause of failure.
         """
         try:
             return RobotChecks.__execute_check("Postcondition", *args)
         except CheckFailed as failure:
             failure.ROBOT_CONTINUE_ON_FAILURE = False
-            raise failure            
+            raise failure
 
     def check_that(self, *args):
         """
@@ -101,7 +101,7 @@ class RobotChecks:
         Check that takes values and/or robot keywords as input and evaluates the results. If the
         check fails it causes the test case to fail. If all keywords were executed correctly and
         only the check fails, the test will continue to execute remaining keywords and checks.
-        
+
         Check that has two basic forms.
         - A single keyword (with its arguments) can be evaluated to a truth value
         - Two values or keywords (with their arguments) can be evaluated using an operator. It will
@@ -109,14 +109,14 @@ class RobotChecks:
 
         Operator can be any Robot keyword taking exactly two values (left and right operands) as
         input. A number of predefined operators on numeric, string and list types are included in
-        this library.        
+        this library.
 
         Examples:
         | `Check that` | 3 | `=` | 3 |
         | `Check that` | Two times | 6 | `equals` | 12 |
         | `Check that` | Two times | 5 | `≠` | Two times | 7 |
         | `Check that` | Earth exists |
-        
+
         'Two times' in these examples is assumed to be defined as a Robot keyword that takes one
         argument and multiplies it by 2. Check that will pass if the evaluated result of Two times 9
         equals the fixed expected value 18.
@@ -125,15 +125,15 @@ class RobotChecks:
                 Any check can be extended with an additional timing constraint by adding ``within``
                 This will cause the condition to be reevaluated until it becomes true, or until
                 the specified time has passed. In the latter case the test case will fail.
-                
+
         Example with time constraint:
         | `Check that` | condition is true | within | 1 minute 30 seconds |
-        
+
         Elevator example:
         | `Check that` | elevator doors are closed |
         | Request elevator at floor | 3 |
         | `Check that` | elevator floor | `equals` | 3 | within | 20 seconds |
-        | `Check that` | offset to floor level in mm | `≤` | 5 | within | 3 seconds | 
+        | `Check that` | offset to floor level in mm | `≤` | 5 | within | 3 seconds |
         """
         return RobotChecks.__execute_check("Requirement", *args)
 
@@ -176,7 +176,7 @@ class RobotChecks:
     def check_interactive(self):
         """
         Suspends test execution to accept manual input of keywords.
-        
+
         A single ``Check interactive`` will repeatedly accept keyword input. Errors from keywords will
         not stop the test case, instead test execution continues until 'Cancel' is clicked or 'exit' is entered.
         There is no timeout. Test execution is suspended indefinitely.
@@ -210,7 +210,7 @@ class RobotChecks:
     def __execute_check(checkType, *args):
         """
         Parse arguments for check keyword to determine its operands, evaluate them and execute the
-        check. 
+        check.
         """
         Arguments = list(args)
 
@@ -222,7 +222,7 @@ class RobotChecks:
         if len(Arguments) >= 2 and str(Arguments[-2]).lower() == 'within':
             EvaluatedTimeArg = RobotChecks.__evaluateOperand([Arguments[-1]])[0]
             TimeOutInSeconds = timestr_to_secs(EvaluatedTimeArg)
-            s_TimeConstraint = Arguments[-1] 
+            s_TimeConstraint = Arguments[-1]
             Arguments = Arguments[:-2]
 
         if not len(Arguments):
@@ -242,7 +242,7 @@ class RobotChecks:
 
         else: # Interpret as expression
             LeftOperand.append(Arguments.pop(0))
-    
+
             NextArgument = Arguments.pop(0)
             while not is_keyword(NextArgument):
                 LeftOperand.append(NextArgument)
@@ -270,7 +270,7 @@ class RobotChecks:
                 BuiltIn().log("Evaluating boolean expression: %s" % (LeftOperand))
                 # Evaluate boolean expression
                 lValue, s_LeftOperand = RobotChecks.__evaluateOperand(LeftOperand)
-                EvaluatedResult = "failed" if str(lValue).lower() != "true" else "passed" 
+                EvaluatedResult = "failed" if str(lValue).lower() != "true" else "passed"
 
             else:
                 lValue, s_LeftOperand = RobotChecks.__evaluateOperand(LeftOperand)
@@ -282,7 +282,7 @@ class RobotChecks:
                     BuiltIn().log("Evaluating '%s' '%s'" % (OperatorKeyword, lValue))
                     EvaluatedResult = BuiltIn().run_keyword(OperatorKeyword, lValue)
 
-                EvaluatedResult = "failed" if str(EvaluatedResult).lower() != "true" else "passed" 
+                EvaluatedResult = "failed" if str(EvaluatedResult).lower() != "true" else "passed"
 
             EvaluationDuration = time.perf_counter() - EvaluationStartTime
 
@@ -301,11 +301,11 @@ class RobotChecks:
 
         # Do reporting
         if OperatorKeyword is None:
-            ReportString = "%s check on '%s'" % (checkType, s_LeftOperand)
+            ReportString = f"{checkType} check on '{s_LeftOperand}'"
         elif not RightOperand:
-            ReportString = "%s check on '%s %s'" % (checkType, OperatorKeyword, s_LeftOperand)
+            ReportString = f"{checkType} check on '{OperatorKeyword} {s_LeftOperand}'"
         else:
-            ReportString = "%s check on '%s %s %s'" % (checkType, s_LeftOperand, OperatorKeyword, s_RightOperand)
+            ReportString = f"{checkType} check on '{s_LeftOperand} {OperatorKeyword} {s_RightOperand}'"
 
         if s_TimeConstraint:
             ReportString += " within %s" % secs_to_timestr(TimeOutInSeconds)
@@ -326,29 +326,29 @@ class RobotChecks:
 
         if is_keyword(operand[0]):
             Value = BuiltIn().run_keyword(*operand)
-            BuiltIn().log("'%s' is '%s'" % (s_Operand, Value))
+            BuiltIn().log(f"'{s_Operand}' is '{Value}'")
             s_Value = str(Value)
 
         else:
             if len(operand) == 1:
                 Value = BuiltIn().replace_variables(operand[0])
                 if Value == operand[0]:
-                    BuiltIn().log("Interpreting '%s' as fixed value" % s_Operand, level='DEBUG')
+                    BuiltIn().log(f"Interpreting '{s_Operand}' as fixed value", level='DEBUG')
                 else:
                     s_Value = str(Value)
-                    BuiltIn().log("Interpreting '%s' as fixed value '%s'" % (s_Operand, s_Value), level='DEBUG')
+                    BuiltIn().log(f"Interpreting '{s_Operand}' as fixed value '{s_Value}'", level='DEBUG')
 
             else:
                 Value = list()
                 for item in operand:
                     Value.append(BuiltIn().replace_variables(item))
                 s_Value = str(Value)
-                BuiltIn().log("Interpreting '%s' as list '%s'" % (s_Operand, s_Value), level='DEBUG')
+                BuiltIn().log(f"Interpreting '{s_Operand}' as list '{s_Value}'", level='DEBUG')
 
         if s_Value:
             if len(s_Value) > 83:
                 s_Value = s_Value[:40] + "..." + s_Value[-40:]
 
-            s_Operand += " [%s]" % s_Value
+            s_Operand += f" [{s_Value}]"
 
         return Value, s_Operand

--- a/robotnl/inline_keywords.py
+++ b/robotnl/inline_keywords.py
@@ -109,11 +109,16 @@ class InlineKeywordConverter(TypeConverter):
     def _convert(self, value, explicit_type=True):
         if not is_keyword(value):
             raise ValueError
-        BuiltIn().log("Evaluating argument as keyword [%s]" % value)
+        BuiltIn().log(f"Evaluating argument as keyword [{value}]")
         result = BuiltIn().run_keyword(value)
-        BuiltIn().log("%s → %s" % (value, result))
+        BuiltIn().log(f"{value} → {result}")
         if self.converter:
-            result = self.converter.convert(str(result), result, explicit_type)
+            try:
+                result = self.converter.convert(f"result of: {value}", result, explicit_type)
+            except ValueError as err:
+                BuiltIn().log(f"Incorrect keyword return type: {err}")
+                raise
+
         return result
 
 

--- a/robotnl/version.py
+++ b/robotnl/version.py
@@ -1,1 +1,1 @@
-VERSION = '2.1.1'
+VERSION = '2.2.0'


### PR DESCRIPTION
Basic type conversions have been part of robotnl since before type conversions were supported by Robot Framework. Now that Robot Framework has surpassed the local implementation it is time to tag along.