### PR TITLE
Robot framework 7 support

### DIFF
--- a/atest/robotNL tests/Check that/Operators/Typed_checks.robot
+++ b/atest/robotNL tests/Check that/Operators/Typed_checks.robot
@@ -33,6 +33,7 @@ float comparisons
     Check that    ${1}    equals    1.0
     Check that    ${1.2}    does not equal    1.21
     Check that    ${1.2}    does not equal    random text
+    Check That    1.2    Does Not Equal    ${1}
 
 bool comparisons
     Check that    True

--- a/atest/robotNL tests/Inline kw arguments/LibDoc.robot
+++ b/atest/robotNL tests/Inline kw arguments/LibDoc.robot
@@ -1,0 +1,8 @@
+*** Settings ***
+Resource          base.resource
+Library           libdoclib.py
+
+*** Test Cases ***
+Inline keywords are registered as type
+    Run Libdoc
+    Check that    libdoc registered types    Contains    InlineKeyword

--- a/atest/robotNL tests/Inline kw arguments/inline_kw_args.robot
+++ b/atest/robotNL tests/Inline kw arguments/inline_kw_args.robot
@@ -13,7 +13,7 @@ with typing
     Should be equal    ${value}    ${12}
 
 with wrong type
-    Run Keyword And Expect Error    REGEXP: .*cannot be converted to integer or inline keyword.    echo int    three quarters
+    Run Keyword And Expect Error    REGEXP: .*cannot be converted to integer or keyword returning integer.    echo int    three quarters
 
 string should stay a string
     ${value}=    echo    not a keyword

--- a/atest/robotNL tests/Inline kw arguments/libdoclib.py
+++ b/atest/robotNL tests/Inline kw arguments/libdoclib.py
@@ -1,0 +1,20 @@
+import json
+import os
+import tempfile
+
+from robot.libdoc import libdoc
+
+class libdoclib:
+    def __init__(self):
+        self.output = {}
+
+    def run_libdoc(self):
+        self.output = {}
+        libfile = os.path.join(os.path.dirname(__file__), 'inline_kw_args.py')
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            outfile = os.path.join(tmpdirname, "libdoc_gen.json")
+            libdoc(libfile, outfile)
+            self.output = json.load(open(outfile))
+
+    def libdoc_registered_types(self):
+        return [td['name'] for td in self.output['typedocs']]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "robotframework-nl"
-version = "2.2.1"
+version = "3.0.0"
 description = "robotnl is a proving ground to boost Robot framework closer to Natural Language."
 readme = "README.md"
 authors = [{ name = "Johan Foederer", email = "github@famfoe.nl" }]
@@ -19,7 +19,7 @@ classifiers = [
 ]
 keywords = ["robotframework", "robot", "testing", "dsl"]
 dependencies = [
-    "robotframework >= 6.0",
+    "robotframework >= 7.0",
 ]
 requires-python = ">=3.8"
 

--- a/robotnl/CheckOperator.py
+++ b/robotnl/CheckOperator.py
@@ -30,6 +30,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from robot.api import TypeInfo
 from robot.libraries.BuiltIn import BuiltIn
 from robot.running.arguments import TypeConverter
 
@@ -192,10 +193,10 @@ class OperatorProxy:
         returns type casted otherValue
         """
         CastedOther = otherValue # By default leave untouched
-        converter = TypeConverter.converter_for(type(leadingValue))
+        converter = TypeConverter.converter_for(TypeInfo.from_type(type(leadingValue)))
         if converter:
             try:
-                CastedOther = converter.convert(name, otherValue, explicit_type=False)
+                CastedOther = converter.convert(otherValue, name)
             except ValueError as err:
                 BuiltIn().log(err, level='DEBUG')
             BuiltIn().log(f"Comparing as {converter.type_name} values")

--- a/robotnl/inline_keywords.py
+++ b/robotnl/inline_keywords.py
@@ -80,7 +80,6 @@ class InlineKeyword(Generic[TypeVar('T')]):
     Inline keywords are keywords that are used as argument to other keywords. The keyword will be
     evaluated and its return value used as the actual argument.
     """
-    _name = 'inline keyword'
 
 
 # work around for Libdoc

--- a/robotnl/version.py
+++ b/robotnl/version.py
@@ -1,1 +1,1 @@
-VERSION = '2.2.1'
+VERSION = '3.0.0'


### PR DESCRIPTION
Note that with this update older versions of Robot Framework are no longer supported due to incompatible changes.