### PR TITLE
new type conversion tests for inline keywords

### DIFF
--- a/atest/robotNL tests/02__Inline kw arguments/inline_kw_args.py
+++ b/atest/robotNL tests/02__Inline kw arguments/inline_kw_args.py
@@ -15,9 +15,13 @@ class inline_kw_args:
     @keyword(name="echo")
     def mirror(self, arg):
         return arg
-        
+
     @keyword(name="echo int")
-    def mirror_typed(self, arg:int):
+    def mirror_int(self, arg:int):
+        return arg
+
+    @keyword(name="echo float")
+    def mirror_float(self, arg:float):
         return arg
 
     @keyword(name="arg stuff")

--- a/atest/robotNL tests/02__Inline kw arguments/inline_kw_args.robot
+++ b/atest/robotNL tests/02__Inline kw arguments/inline_kw_args.robot
@@ -8,9 +8,17 @@ without typing
     ${value}=    echo    twelve
     Should be equal    ${value}    ${12}
 
-with typing
+with int typing
     ${value}=    echo int    twelve
-    Should be equal    ${value}    ${12}
+    Should be equal    ${value}    ${12}    type=int
+
+with float typing
+    ${value}=    echo float    three quarters
+    Should be equal    ${value}    ${0.75}    type=float
+
+with return type conversion
+    ${value}=    echo float    twelve
+    Should be equal    ${value}    ${12.0}    type=float
 
 with wrong type
     Run Keyword And Expect Error    REGEXP: .*cannot be converted to integer or keyword returning integer.    echo int    three quarters


### PR DESCRIPTION
While working on the type converter api for Robot framework, I ran into some issues when using multiple converters for generic types that have different nested types, like the inline keyword type. I realised that these cases were not yet covered in the RobotNL test suite.