### PR TITLE
Python 3.14 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "robotframework-nl"
-version = "3.2.0"
+version = "4.0.0"
 description = "robotnl is a proving ground to boost Robot framework closer to Natural Language."
 readme = "README.md"
 authors = [{ name = "Johan Foederer", email = "github@famfoe.nl" }]
@@ -21,7 +21,7 @@ keywords = ["robotframework", "robot", "testing", "dsl"]
 dependencies = [
     "robotframework >= 7.0",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.14"
 
 [tool.setuptools]
 packages = ["robotnl"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=61.0.0",
+    "setuptools>=83.0.0",
     "wheel"
 ]
 build-backend = "setuptools.build_meta"
@@ -8,12 +8,12 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "robotframework-nl"
 version = "4.0.0"
-description = "robotnl is a proving ground to boost Robot framework closer to Natural Language."
+description = "RobotNL is a proving ground to boost Robot Framework closer to Natural Language."
 readme = "README.md"
 authors = [{ name = "Johan Foederer", email = "github@famfoe.nl" }]
-license = { file = "LICENSE" }
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 classifiers = [
-    "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",
 ]

--- a/robotnl/inline_keywords.py
+++ b/robotnl/inline_keywords.py
@@ -35,6 +35,7 @@ from robot.api.deco import keyword as robot_keyword
 from robot.utils import type_name
 from robot.running.arguments import TypeConverter
 
+from annotationlib import get_annotations, Format
 from functools import wraps
 from typing import TypeVar, Generic, Union
 
@@ -102,7 +103,7 @@ class InlineKeywordConverter(TypeConverter):
 
     def _convert(self, value):
         if not is_keyword(value):
-            raise ValueError
+            raise ValueError("Not a keyword")
         BuiltIn().log(f"Evaluating argument as keyword [{value}]")
         result = BuiltIn().run_keyword(value)
         BuiltIn().log(f"{value} → {result}")
@@ -116,11 +117,16 @@ class InlineKeywordConverter(TypeConverter):
 
         return result
 
-
 def keyword(name=None, tags=(), types=()):
     def decorator(func):
-        for var, type_ in func.__annotations__.items():
-            func.__annotations__[var] = Union[type_, InlineKeyword[type_]]
+        annotations = get_annotations(func, format=Format.VALUE)
+        for var, type_ in annotations.items():
+            annotations[var] = Union[type_, InlineKeyword[type_]]
+
+        def new_annotate(self, format=Format.VALUE):
+            return annotations
+        func.__annotate__ = new_annotate
+
         @robot_keyword(name, tags, types)
         @wraps(func)
         def wrapped(*args, **kwargs):

--- a/robotnl/version.py
+++ b/robotnl/version.py
@@ -1,1 +1,1 @@
-VERSION = '3.2.0'
+VERSION = '4.0.0'


### PR DESCRIPTION
Due to a change in Python's type annotation system, the type inference for return types of inline keywords needs to follow along.